### PR TITLE
basic認証解除

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,14 +1,7 @@
 class ApplicationController < ActionController::Base
-  before_action :basic_auth
   before_action :configure_permitted_parameters, if: :devise_controller?
 
   private
-
-  def basic_auth
-    authenticate_or_request_with_http_basic do |username, password|
-      username == ENV['BASIC_AUTH_USER'] && password == ENV['BASIC_AUTH_PASSWORD']
-    end
-  end
 
   def configure_permitted_parameters
     devise_parameter_sanitizer.permit(:sign_up, keys: [:name, :name_kana, :employee_id])


### PR DESCRIPTION
#What
basic認証の解除
#Why
選考過程での閲覧工程を減らすため